### PR TITLE
make sure you get to the admin page

### DIFF
--- a/client/partials/admin/admin.html
+++ b/client/partials/admin/admin.html
@@ -145,7 +145,7 @@
 <!-- seperated so that I can use it on the actual site if an admin is logged in -->
 <template name="adminHeader">
   <div class="adminHeader">
-    <div class="page" onclick="window.location.href='admin'">
+    <div class="page" onclick="window.location.href='/admin'">
       {{#if equals currentPage "admin"}}
       Home
       {{else}}


### PR DESCRIPTION
Make the admin link an absolute link rather than a relative one.
This is to make sure you always get to /admin from anywhere on the site.
Yes, i'm looking at you http://thecabal.online/p/N1eiZ4mam => http://thecabal.online/p/admin